### PR TITLE
391623: Update 'Owner' field in catalog-info.yaml

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -8,4 +8,4 @@ metadata:
 spec:
   type: documentation
   lifecycle: experimental
-  owner: ADP
+  owner: "group:default/ccts-adp"


### PR DESCRIPTION
Updated the 'owner' field.

[391623](https://dev.azure.com/defragovuk/DEFRA-FFC/_workitems/edit/391623/)